### PR TITLE
Dont migrate sqlite

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,27 +47,6 @@ exists, it will migrate. For more details on how this works, see the Alembic doc
 **A migration must be run before the app is started on a fresh database!**
 Otherwise the tables will not exist. (The app code itself no longer creates tables.)
 
-> ### Local Testing
->
-> What we've learned in the previous two sections about the `DATABASE_URL` variable and the requirement that migrations be run prior to starting the API informs the local testing approach. To set up local testing, run
->
-> ```bash
-> export DATABASE_URL=sqlite:///`pwd`/database.sqlite
-> ```
->
-> to assign the required environment variable. Then run the migrations with
->
-> ```bash
-> python -m alembic upgrade head
-> ```
->
-> And finally, invoke the tests
->
-> ```bash
-> pytest -vx
-> ```
->
-> Note that `.sqlite` files are excluded by `.gitignore`, so you don't need to worry about the database file appearing in your commit.
 ### Creating a new Database Version
 
 Any time the SQLModel table models are changed in any way, a new migration
@@ -84,6 +63,23 @@ when we want to migrate.
 If the migration is complex or ambiguous, the migration script might have to be
 tweaked manually.
 
+
+## Local Testing
+
+Migrations are not used for local testing with SQLite. To setup local testing, simply define the `DATABASE_URL` environment variable
+
+```bash
+export DATABASE_URL=sqlite:///`pwd`/database.sqlite
+```
+and then invoke the tests
+
+```bash
+pytest -vx
+```
+
+A new SQLite database file will be automatically created for each test session and populated with tables based on the `pangeo_forge_orchestrator.models` module.
+
+> Note that `.sqlite` files are excluded by `.gitignore`, so you don't need to worry about the database file appearing in your commit.
 
 ## Heroku Deployment
 

--- a/README.md
+++ b/README.md
@@ -77,9 +77,10 @@ and then invoke the tests
 pytest -vx
 ```
 
-A new SQLite database file will be automatically created for each test session and populated with tables based on the `pangeo_forge_orchestrator.models` module.
-
-> Note that `.sqlite` files are excluded by `.gitignore`, so you don't need to worry about the database file appearing in your commit.
+> If no file exists at the `DATABASE_URL`, a new SQLite database file will be automatically created for the test session and populated
+with tables based on `pangeo_forge_orchestrator.models`. If a file already exists at the at the `DATABASE_URL`, it will be updated
+to refect the tables defined by `pangeo_forge_orchestrator.models`. Note that `.sqlite` files are excluded by `.gitignore`, so you don't
+need to worry about the database file appearing in your commit.
 
 ## Heroku Deployment
 

--- a/pangeo_forge_orchestrator/api.py
+++ b/pangeo_forge_orchestrator/api.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from sqlmodel import Session
 
-from .database import engine
+from .database import create_sqlite_db_and_tables, engine
 from .model_builders import register_endpoints
 from .models import MODELS
 
@@ -11,6 +11,12 @@ app = FastAPI()
 def get_session():
     with Session(engine) as session:
         yield session
+
+
+@app.on_event("startup")
+def on_startup():
+    if engine.url.drivername == "sqlite":
+        create_sqlite_db_and_tables()
 
 
 for k in MODELS.keys():

--- a/pangeo_forge_orchestrator/database.py
+++ b/pangeo_forge_orchestrator/database.py
@@ -13,3 +13,8 @@ elif database_url.startswith("postgres://"):  # pragma: no cover
     database_url = database_url.replace("postgres://", "postgresql://", 1)
 
 engine = create_engine(database_url, echo=True, connect_args=connect_args)
+
+
+def create_sqlite_db_and_tables():
+    # Called from `.api`; requires `.models` import to register metadata
+    SQLModel.metadata.create_all(engine)

--- a/pangeo_forge_orchestrator/database.py
+++ b/pangeo_forge_orchestrator/database.py
@@ -17,4 +17,5 @@ engine = create_engine(database_url, echo=True, connect_args=connect_args)
 
 def create_sqlite_db_and_tables():
     # Called from `.api`; requires `.models` import to register metadata
+    # https://sqlmodel.tiangolo.com/tutorial/create-db-and-table/#refactor-data-creation
     SQLModel.metadata.create_all(engine)


### PR DESCRIPTION
[SQLite supports a limited subset of ALTER TABLE.](https://www.sqlite.org/lang_altertable.html). This creates [problems for Alembic](https://stackoverflow.com/a/32510603). Rather than changing our Alembic config to work with SQLite, this PR proposes that we use SQLModel to generate databases for local testing.