### PR TITLE
Upgrade sqlmodel to resolve alembic indexing issue

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,17 +27,8 @@ packages = find:
 include_package_data = True
 install_requires =
     fastapi >= 0.70.0
-    sqlmodel >= 0.0.4
+    sqlmodel >= 0.0.6  # https://github.com/tiangolo/sqlmodel/issues/9#issuecomment-1002044383
     typer >= 0.4.0
-    # cf_xarray >= 0.6.1
-    # fsspec >= 2021.10.0
-    # gcsfs >= 2021.10.0
-    # pangeo-forge-recipes >= 0.6.1
-    # pydantic >= 1.8.2
-    # rich >= 10.12.0
-    # s3fs >= 2021.10.0
-    # shapely >= 1.7.1
-    # xstac @ git+https://github.com/cisaacstern/xstac@cfxr
 
 [options.extras_require]
 dev =


### PR DESCRIPTION
Closes #36

@rabernat, the issue you linked to in https://github.com/pangeo-forge/pangeo-forge-orchestrator/pull/31#discussion_r790374910 reveals that the alembic indexing problem was [resolved in SQLModel `0.0.6`](https://github.com/tiangolo/sqlmodel/issues/9#issuecomment-1002044383)

I tried generating an arbitrary migration after upgrading SQLModel to `0.0.6` and no indexes were created. 🎉 

