### PR TITLE
Add cors middleware for all origins

### DIFF
--- a/pangeo_forge_orchestrator/api.py
+++ b/pangeo_forge_orchestrator/api.py
@@ -1,6 +1,7 @@
 import os
 
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.httpsredirect import HTTPSRedirectMiddleware
 
 from .database import maybe_create_db_and_tables
@@ -14,6 +15,16 @@ app = FastAPI(**app_metadata)
 
 if os.environ.get("PANGEO_FORGE_DEPLOYMENT", False):
     app.add_middleware(HTTPSRedirectMiddleware)
+
+origins = ["*"]  # is this dangerous? I can't see why.
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 @app.on_event("startup")


### PR DESCRIPTION
CORS is a deep and annoying topic. Without this, javascript sites cannot query the API unless they are coming from the same exact domain where the api is deployed. We should revisit this once we get an actual frontend person on this project.