### PR TITLE
Pin sqlalchemy==1.4.35

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ aiohttp==3.8.1
 fastapi==0.71.0
 gidgethub==5.1.0
 sqlmodel==0.0.6
+sqlalchemy == 1.4.35  # https://github.com/tiangolo/sqlmodel/issues/315
 typer==0.4.0
 alembic==1.7.5
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
     fastapi >= 0.70.0
     gidgethub >= 5.1.0
     sqlmodel >= 0.0.6  # https://github.com/tiangolo/sqlmodel/issues/9#issuecomment-1002044383
+    sqlalchemy == 1.4.35  # https://github.com/tiangolo/sqlmodel/issues/315
     typer >= 0.4.0
 
 [options.extras_require]


### PR DESCRIPTION
Thanks to @andersy005 for surfacing this issue in https://github.com/pangeo-forge/pangeo-forge-orchestrator/pull/69, and for a very helpful debugging session together on Friday. 🙏 

I found that the tests did still pass in my original dev environment from when we first deployed this repo (which I still had saved on my laptop), which suggested to me this had to be a problem with some recent release of a project dependency (because only new installations break the tests).

Some digging turned up https://github.com/tiangolo/sqlmodel/issues/315, which is exactly our issue (broken relationship attributes with SQLAlchemy > 1.4.35. Pinning `sqlalchemy==1.4.35` solves this issue for now. I will open a separate issue here to track the upstream problem, so that we can release this pin once it is solved upstream.

(I'd of course like to contribute a solution upstream, but this issue has been open on SQLModel since April, with at least one potential PR fix also open there, yet these tickets don't seem to have gotten any engagement from core maintainers. It's also unclear to me if this needs to be fixed in SQLModel or SQLAlchemy. I'll look into this further and open an issue on SQLAlchemy if one doesn't yet exist.)