### PR TITLE
Drop pyscopg2 from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,6 @@ install_requires =
     gidgethub >= 5.1.0
     sqlmodel >= 0.0.6  # https://github.com/tiangolo/sqlmodel/issues/9#issuecomment-1002044383
     sqlalchemy == 1.4.35  # https://github.com/tiangolo/sqlmodel/issues/315
-    psycopg2  # for postgres
     psycopg2-binary  # for postgres
 
 [options.extras_require]


### PR DESCRIPTION
Following @andersy005's ping in https://github.com/pangeo-forge/staged-recipes/pull/175#issuecomment-1224991263, I tracked down the corresponding actions log here:

> https://github.com/pangeo-forge/registrar/runs/7984326755?check_suite_focus=true

which suggests the problem is that `registrar` is unable to install `pangeo-forge-orchestrator` because of the presence of `psycopg2` in the install dependencies. I'm nearly certain `psycopg2` is redundant with `psycopg2-binary`, so just dropping it here.