### PR TITLE
Test fixtures improvements

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -168,6 +168,20 @@ def clear_table(session: Session, table_model: SQLModel):
     assert len(session.query(table_model).all()) == 0  # make sure the database is empty
 
 
+def clear_database():
+    # note this function is redundant with the `session` fixture below
+    # the difference is that this called explictly by the newer fixtures in `test_github_app`
+    # whereas the `session` fixture is called implicitly for the older fixtues used by `test_api`
+    # eventually, we should replace the older implict `session` with this more explicit approach
+    # for all tests. in the short term, to avoid breaking the older tests, we'll keep this as two
+    # separate approaches.
+    from pangeo_forge_orchestrator.database import engine
+
+    with Session(engine) as session:
+        for k in MODELS:
+            clear_table(session, MODELS[k].table)  # make sure the database is empty
+
+
 @pytest.fixture(scope="session")
 def api_keys():
     salt = uuid.uuid4().hex

--- a/tests/test_github_app.py
+++ b/tests/test_github_app.py
@@ -23,6 +23,8 @@ from pangeo_forge_orchestrator.routers.github_app import (
     list_accessible_repos,
 )
 
+from .conftest import clear_database
+
 
 def mock_access_token_from_jwt(jwt: str):
     """Certain GitHub API actions are authenticated via JWT and others are authenticated with an
@@ -378,16 +380,7 @@ async def check_run_create_kwargs(admin_key, async_app_client):
     )
 
     # database teardown
-    from sqlmodel import Session
-
-    from pangeo_forge_orchestrator.database import engine
-    from pangeo_forge_orchestrator.models import MODELS
-
-    from .conftest import clear_table
-
-    with Session(engine) as session:
-        for k in MODELS:
-            clear_table(session, MODELS[k].table)  # make sure the database is empty
+    clear_database()
 
 
 @pytest.mark.asyncio
@@ -540,16 +533,7 @@ async def synchronize_request(
     yield add_hash_signature(request, webhook_secret)
 
     # database teardown
-    from sqlmodel import Session
-
-    from pangeo_forge_orchestrator.database import engine
-    from pangeo_forge_orchestrator.models import MODELS
-
-    from .conftest import clear_table
-
-    with Session(engine) as session:
-        for k in MODELS:
-            clear_table(session, MODELS[k].table)  # make sure the database is empty
+    clear_database()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
@andersy005, these incremental improvements to the test fixtures should hopefully allow us to write a test for #95 without tying ourselves into knots. In brief, by moving the database setup/teardown into the fixture, we make what's being tested clearer. I'll merge this, then sync #95 to `main`, and then give you a suggestion on #95 of how to test the new feature.