### PR TITLE
Add gitleaks action & pre-commit

### DIFF
--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -1,0 +1,19 @@
+name: gitleaks
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 4 * * *' # run once a day at 4 AM
+jobs:
+  scan:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,11 @@ repos:
     hooks:
       - id: sops-encryption
 
+  - repo: https://github.com/zricethezav/gitleaks
+    rev: v8.12.0
+    hooks:
+      - id: gitleaks
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
     hooks:


### PR DESCRIPTION
Per @yuvipanda's recommendation, we should have two things configured on this repo, now that it's public (#68):

- https://github.com/yuvipanda/pre-commit-hook-ensure-sops 
- https://github.com/zricethezav/gitleaks

We already have the first, and this PR adds the second.

For gitleaks, I'm adding the pre-commit hook (as hopefully a first filter on developers' local machines) as well as the GitHub Action (because this will presumably give a better UI. we could remove this in favor of _just_ the pre-commit hook eventually if we find it redundant).