### PR TITLE
Add pangeo-forge-esgf + python-cmr to app container

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,8 @@ s3fs==2022.8.2
 # these will eventually be brought into the recipe parsing container dynamically
 # from requirements.txt, environment.yml, etc. For now, we are hardcoding so that
 # we can work on the feedstocks that require them.
-pangeo-forge-esgf
+pangeo-forge-esgf==0.0.3
+python-cmr==0.7.0
 
 # for `/repr/xarray/` route
 zarr

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,11 @@ pangeo-forge-runner==0.5
 gcsfs==2022.8.2
 s3fs==2022.8.2
 
+# these will eventually be brought into the recipe parsing container dynamically
+# from requirements.txt, environment.yml, etc. For now, we are hardcoding so that
+# we can work on the feedstocks that require them.
+pangeo-forge-esgf
+
 # for `/repr/xarray/` route
 zarr
 xarray>=2022.06


### PR DESCRIPTION
@jbusecke's https://github.com/pangeo-forge/staged-recipes/pull/162 requires `pangeo-forge-esgf`. Also @briannapagan's [GPM_3IMERGHHL](https://github.com/briannapagan/staged-recipes/blob/master/recipes/GPM_3IMERGHHL/GPM_3IMERGHHL.py) requires `python-cmr`. Eventually, we plan to support dynamic installations of packages like this: https://github.com/pangeo-forge/pangeo-forge-runner/issues/27. For now, we're just hardcoding this to unblock them.

cc @yuvipanda 