### PR TITLE
Add .gitleaksignore

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,1 @@
+f9d6af54b7cfa29912f07d90ab7e999b674fe4e8:app.json:generic-api-key:24


### PR DESCRIPTION
The nightly runs of gitleaks keep failing because they find this one old (and long-since unused) credential for a review app. It's the same one [linked here](https://github.com/pangeo-forge/pangeo-forge-orchestrator/issues/68#issuecomment-1255379391). The .gitleaksignore added here tells gitleaks to ignore that hit for future runs. I've confirmed it works locally, hopefully it works in the nightly CI as well!