### PR TITLE
Revert back to three Gunicorn workers

### DIFF
--- a/heroku.yml
+++ b/heroku.yml
@@ -28,4 +28,4 @@ run:
     && export GOOGLE_APPLICATION_CREDENTIALS=${DATAFLOW_CREDS}
     && export BAKERY_SECRETS='./secrets/bakery-args.pangeo-ldeo-nsf-earthcube.yaml'
     && sops -d -i ${BAKERY_SECRETS}
-    && gunicorn -w 2 -t 300 -k uvicorn.workers.UvicornWorker pangeo_forge_orchestrator.api:app
+    && gunicorn -w 3 -t 300 -k uvicorn.workers.UvicornWorker pangeo_forge_orchestrator.api:app


### PR DESCRIPTION
After merging https://github.com/pangeo-forge/pangeo-forge-orchestrator/pull/178, it turns out the concurrency wasn't the culprit for the memory issue. 

it appears the S3 bucket crawling from https://github.com/pangeo-forge/staged-recipes/pull/215 may be the root cause of observed memory spikes and app crashes. 