### PR TITLE
Replace flake8/isort with ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,20 +22,17 @@ repos:
       - id: debug-statements
       - id: mixed-line-ending
 
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    # Ruff version.
+    rev: 'v0.0.237'
+    hooks:
+      - id: ruff
+        args: ['--fix']
+
   - repo: https://github.com/psf/black
     rev: 22.12.0
     hooks:
       - id: black
-
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
-    hooks:
-      - id: flake8
-
-  - repo: https://github.com/asottile/seed-isort-config
-    rev: v2.2.0
-    hooks:
-      - id: seed-isort-config
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: 'v0.991'
@@ -43,11 +40,6 @@ repos:
       - id: mypy
         additional_dependencies:
           - 'pydantic'
-
-  - repo: https://github.com/pycqa/isort
-    rev: 5.11.4
-    hooks:
-      - id: isort
 
   - repo: https://github.com/rstcheck/rstcheck
     rev: v6.1.1

--- a/pangeo_forge_orchestrator/config.py
+++ b/pangeo_forge_orchestrator/config.py
@@ -1,7 +1,7 @@
 import json
 import os
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Optional
 
 import yaml  # type: ignore
 from pydantic import BaseModel, Extra, Field, SecretStr
@@ -19,7 +19,7 @@ class GitHubAppConfig(BaseModel):
     app_name: str
     webhook_secret: str
     private_key: str
-    run_only_on: Optional[List[str]] = None
+    run_only_on: Optional[list[str]] = None
 
 
 def get_gcr_container_image_url():
@@ -102,7 +102,7 @@ class Bakery(BaseModel):
 class Config(BaseModel):
     fastapi: FastAPIConfig
     github_app: GitHubAppConfig
-    bakeries: Dict[str, Bakery]
+    bakeries: dict[str, Bakery]
 
 
 def get_app_config_path() -> str:
@@ -140,7 +140,7 @@ def get_secrets_dir():
     return f"{root}/secrets"
 
 
-def get_secret_bakery_args_paths() -> List[str]:
+def get_secret_bakery_args_paths() -> list[str]:
     return [p for p in os.listdir(get_secrets_dir()) if p.startswith("bakery-args")]
 
 

--- a/pangeo_forge_orchestrator/model_builders.py
+++ b/pangeo_forge_orchestrator/model_builders.py
@@ -1,6 +1,6 @@
 import types
 from dataclasses import dataclass
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from sqlmodel import Field, Relationship, SQLModel
 
@@ -21,7 +21,7 @@ class RelationBuilder:
     """
 
     field: str
-    annotation: Union[SQLModel, List[str]]
+    annotation: Union[SQLModel, list[str]]
     back_populates: str
 
 
@@ -65,7 +65,7 @@ class MultipleModels:
     response: SQLModel
     descriptive_name: str
     extended_response: Optional[SQLModel] = None
-    relations: Optional[List[RelationBuilder]] = None
+    relations: Optional[list[RelationBuilder]] = None
 
     def __post_init__(self):
         self.creation: SQLModel = self.make_creator_cls()

--- a/pangeo_forge_orchestrator/models.py
+++ b/pangeo_forge_orchestrator/models.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from enum import Enum
-from typing import List, Optional
+from typing import Optional
 
 from sqlmodel import Field, SQLModel
 
@@ -155,11 +155,11 @@ class RecipeRunRead(RecipeRunBase):
 
 
 class BakeryReadWithRecipeRuns(BakeryRead):
-    recipe_runs: List[RecipeRunRead]
+    recipe_runs: list[RecipeRunRead]
 
 
 class FeedstockReadWithRecipeRuns(FeedstockRead):
-    recipe_runs: List[RecipeRunRead]
+    recipe_runs: list[RecipeRunRead]
 
 
 class RecipeRunReadWithBakeryAndFeedstock(RecipeRunRead):
@@ -179,7 +179,7 @@ bakery_models = MultipleModels(
     relations=[
         RelationBuilder(
             field="recipe_runs",
-            annotation=List["RecipeRun"],  # type: ignore # noqa: F821
+            annotation=list["RecipeRun"],  # type: ignore # noqa: F821
             back_populates="bakery",
         ),
     ],
@@ -193,7 +193,7 @@ feedstock_models = MultipleModels(
     relations=[
         RelationBuilder(
             field="recipe_runs",
-            annotation=List["RecipeRun"],  # type: ignore # noqa: F821
+            annotation=list["RecipeRun"],  # type: ignore # noqa: F821
             back_populates="feedstock",
         ),
     ],

--- a/pangeo_forge_orchestrator/routers/github_app.py
+++ b/pangeo_forge_orchestrator/routers/github_app.py
@@ -7,7 +7,7 @@ import tempfile
 import time
 from datetime import datetime
 from textwrap import dedent
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 from urllib.parse import parse_qs, urlparse
 
 import aiohttp
@@ -356,7 +356,7 @@ async def handle_dataflow_event(
 
         # Wow not every day you google a error and see a comment on it by Guido van Rossum
         # https://github.com/python/mypy/issues/1174#issuecomment-175854832
-        args: List[SQLModel] = [recipe_run]  # type: ignore
+        args: list[SQLModel] = [recipe_run]  # type: ignore
         if recipe_run.is_test:
             args.append(feedstock.spec)  # type: ignore
             logger.info(f"Calling `triage_test_run_complete` with {args=}")
@@ -451,10 +451,10 @@ async def handle_pr_comment_event(
 
 async def handle_pr_event(
     *,
-    payload: Dict,
-    gh_kws: Dict[str, Any],
+    payload: dict,
+    gh_kws: dict[str, Any],
     gh: GitHubAPI,
-    session_kws: Dict[str, Any],
+    session_kws: dict[str, Any],
     background_tasks: BackgroundTasks,
 ):
     """Process a PR event."""
@@ -618,7 +618,7 @@ async def make_dataflow_job_name(recipe_run: SQLModel, gh: GitHubAPI):
     # server, and so we do need to preseve that.
     to_encode = p.netloc if p.path == "/github/hooks/" else p.netloc + p.path
     to_encode += "%"  # control character to separate webhook url encoding from recipe run id
-    as_hex = "".join(["{:02x}".format(ord(x)) for x in to_encode])
+    as_hex = "".join([f"{ord(x):02x}" for x in to_encode])
     # decoding is easier if recipe_run id encoded with an even length, so zero-pad if odd.
     # note we are using ``f"0{recipe_run.id}"``, *not* ``f"{recipe_run_id:02}"`` to pad if odd,
     # because we want the *number of digits* to be even regardless of the length of the odd input.

--- a/pangeo_forge_orchestrator/routers/model_router.py
+++ b/pangeo_forge_orchestrator/routers/model_router.py
@@ -1,4 +1,4 @@
-from typing import List, Literal
+from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import and_
@@ -116,7 +116,7 @@ for model_name, model in MODELS.items():
         model.path,
         make_read_range_endpoint(model),
         methods=["GET"],
-        response_model=List[model.response],  # type: ignore
+        response_model=list[model.response],  # type: ignore
         summary=f"Read a range of {model.descriptive_name} objects",
         tags=[model.descriptive_name, "public"],
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,57 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 write_to = "pangeo_forge_orchestrator/_version.py"
 write_to_template = "__version__ = '{version}'"
+
+[tool.ruff]
+line-length = 100
+target-version = "py39"
+builtins = ["ellipsis"]
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".hg",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "venv",
+]
+per-file-ignores = {}
+# E402: module level import not at top of file
+# E501: line too long - let black worry about that
+# E731: do not assign a lambda expression, use a def
+ignore = [
+    "E402",
+    "E501",
+    "E731",
+]
+select = [
+    # Pyflakes
+    "F",
+    # Pycodestyle
+    "E",
+    "W",
+    # isort
+    "I",
+    # Pyupgrade
+    "UP",
+]
+
+
+[tool.ruff.mccabe]
+max-complexity = 18
+
+[tool.ruff.isort]
+known-first-party = ["pangeo_forge_orchestrator"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,21 +54,6 @@ dev =
 console_scripts =
     pangeo-forge = pangeo_forge_orchestrator.cli:cli
 
-[flake8]
-ignore =
-max-line-length = 100
-max-complexity = 18
-select = B,C,E,F,W,T4,B9
-extend-ignore = E203,E501,E402,W605,W503
-
-[isort]
-known_first_party=pangeo_forge_orchestrator
-known_third_party=aiohttp,alembic,asgi_lifespan,cryptography,fastapi,gidgethub,httpx,jwt,pydantic,pytest,pytest_asyncio,pytest_lazyfixture,requests,setuptools,sqlalchemy,sqlmodel,starlette,yaml
-multi_line_output=3
-include_trailing_comma=True
-force_grid_wrap=0
-combine_as_imports=True
-line_length=100
 
 [tool:pytest]
 log_cli = False

--- a/tests/github_app/mock_gidgethub.py
+++ b/tests/github_app/mock_gidgethub.py
@@ -1,7 +1,7 @@
 import hashlib
 import random
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Union
+from typing import Optional, Union
 
 from pangeo_forge_orchestrator.http import HttpSession
 from pangeo_forge_orchestrator.routers.github_app import get_jwt
@@ -22,13 +22,13 @@ def mock_access_token_from_jwt(jwt: str):
 @dataclass
 class _MockGitHubBackend:
     _app_hook_config_url: Optional[str] = None
-    _accessible_repos: Optional[List[dict]] = None
-    _repositories: Optional[Dict[str, dict]] = None
-    _app_hook_deliveries: Optional[List[dict]] = None
-    _app_installations: Optional[List[dict]] = None
-    _check_runs: Optional[List[dict]] = None
-    _pulls: Optional[Dict[str, Dict[int, dict]]] = None
-    _pulls_files: Optional[Dict[str, Dict[int, dict]]] = None
+    _accessible_repos: Optional[list[dict]] = None
+    _repositories: Optional[dict[str, dict]] = None
+    _app_hook_deliveries: Optional[list[dict]] = None
+    _app_installations: Optional[list[dict]] = None
+    _check_runs: Optional[list[dict]] = None
+    _pulls: Optional[dict[str, dict[int, dict]]] = None
+    _pulls_files: Optional[dict[str, dict[int, dict]]] = None
 
 
 @dataclass
@@ -46,7 +46,7 @@ class MockGitHubAPI:
         accept: Optional[str] = None,
         jwt: Optional[str] = None,
         oauth_token: Optional[str] = None,
-    ) -> Union[dict, List[dict]]:
+    ) -> Union[dict, list[dict]]:
         if path == "/app/hook/config":
             return {"url": self._backend._app_hook_config_url}
         # gidgethub allows us to call either the relative or absolute path, and we do both

--- a/tests/github_app/mock_pangeo_forge_runner.py
+++ b/tests/github_app/mock_pangeo_forge_runner.py
@@ -1,9 +1,8 @@
 import json
 from subprocess import CalledProcessError
-from typing import List
 
 
-def mock_subprocess_check_output_raises_called_process_error(cmd: List[str]):
+def mock_subprocess_check_output_raises_called_process_error(cmd: list[str]):
     subcmd = cmd[1]
     if subcmd == "bake":
         loglines = [
@@ -23,7 +22,7 @@ def mock_subprocess_check_output_raises_called_process_error(cmd: List[str]):
     raise CalledProcessError(1, cmd, output)
 
 
-def mock_subprocess_check_output(cmd: List[str]):
+def mock_subprocess_check_output(cmd: list[str]):
     """ """
 
     if cmd[0] == "pangeo-forge-runner":
@@ -42,9 +41,7 @@ def mock_subprocess_check_output(cmd: List[str]):
                 '{"message": "Expansion complete", "status": "completed", "meta": {"title": "Global Precipitation Climatology Project", "description": "Global Precipitation Climatology Project (GPCP) Daily Version 1.3 gridded, merged ty satellite/gauge precipitation Climate data Record (CDR) from 1996 to present.\\n", "pangeo_forge_version": "0.9.0", "pangeo_notebook_version": "2022.06.02", "recipes": [{"id": "gpcp", "object": "recipe:recipe"}], "provenance": {"providers": [{"name": "NOAA NCEI", "description": "National Oceanographic & Atmospheric Administration National Centers for Environmental Information", "roles": ["host", "licensor"], "url": "https://www.ncei.noaa.gov/products/global-precipitation-climatology-project"}, {"name": "University of Maryland", "description": "University of Maryland College Park Earth System Science Interdisciplinary Center (ESSIC) and Cooperative Institute for Climate and Satellites (CICS).\\n", "roles": ["producer"], "url": "http://gpcp.umd.edu/"}], "license": "No constraints on data access or use."}, "maintainers": [{"name": "Ryan Abernathey", "orcid": "0000-0001-5999-4917", "github": "rabernat"}], "bakery": {"id": "pangeo-ldeo-nsf-earthcube"}}}\n'
             )
         elif cmd[1] == "bake":
-            return '{"message": "Submitted job 2022-11-02_09_47_12-7631717319482580875 for recipe NASA-SMAP-SSS/RSS/monthly","recipe": "NASA-SMAP-SSS/RSS/monthly","job_name": "a6170692e70616e67656f2d666f7267652e6f7267251366","job_id": "2022-11-02_09_47_12-7631717319482580875","status": "submitted"}'.encode(
-                "utf-8"
-            )
+            return b'{"message": "Submitted job 2022-11-02_09_47_12-7631717319482580875 for recipe NASA-SMAP-SSS/RSS/monthly","recipe": "NASA-SMAP-SSS/RSS/monthly","job_name": "a6170692e70616e67656f2d666f7267652e6f7267251366","job_id": "2022-11-02_09_47_12-7631717319482580875","status": "submitted"}'
         else:
             raise NotImplementedError(f"Command {cmd} not implemented in tests.")
     else:

--- a/tests/github_app/test_POST_synchronize_event.py
+++ b/tests/github_app/test_POST_synchronize_event.py
@@ -1,6 +1,5 @@
 import json
 import subprocess
-from typing import List
 from urllib.parse import urlparse
 
 import pytest
@@ -187,7 +186,7 @@ async def test_receive_synchronize_request(
     if title.startswith("Add ABC dataset, throws "):
         error_type = title.split()[-1]  # hacky way to get error types fixturized in pr title
 
-        def mock_subprocess_check_output_raises(cmd: List[str]):
+        def mock_subprocess_check_output_raises(cmd: list[str]):
             loglines = [{"status": "failed", "exc_info": f"Traceback\n{error_type}: error msg"}]
             output = "\n".join([json.dumps(line) for line in loglines])
             raise subprocess.CalledProcessError(1, cmd, output)

--- a/tests/github_app/test_helpers_misc.py
+++ b/tests/github_app/test_helpers_misc.py
@@ -1,4 +1,3 @@
-from typing import Tuple
 from urllib.parse import urlparse
 
 import jwt
@@ -150,7 +149,7 @@ async def test_make_dataflow_job_name(app_hook_config_url, recipe_run_id):
     gh_backend = _MockGitHubBackend(**gh_backend_kws)
     mock_gh = get_mock_github_session(gh_backend)(http_session)
 
-    def reverse_encoding(job_name: str) -> Tuple[str, int]:
+    def reverse_encoding(job_name: str) -> tuple[str, int]:
         # TODO: This code is duplicative of the code used in the submodule
         # `dataflow-status-monitoring/src/main.py` to decode job names. Ideally, we should be using
         # the *actual* decoding function to test here, however the submodule code is not currently

--- a/tests/model_fixtures.py
+++ b/tests/model_fixtures.py
@@ -2,9 +2,9 @@
 This is where we put all the data about creating / updating models
 """
 from dataclasses import dataclass, field
-from typing import Dict, List, Sequence, Union
+from typing import Sequence, Union
 
-APIOpts = Dict[str, Union[int, str]]
+APIOpts = dict[str, Union[int, str]]
 
 
 @dataclass
@@ -14,8 +14,8 @@ class ModelFixture:
     create_opts: Sequence[APIOpts]  # valid ways to create the model
     invalid_opts: Sequence[APIOpts]  # setting these on creation or update should error
     update_opts: Sequence[APIOpts]  # setting these on update should be valid
-    dependencies: List["ModelRelationFixture"] = field(default_factory=list)  # req to create model
-    optional_relations: List["ModelRelationFixture"] = field(default_factory=list)  # not required
+    dependencies: list["ModelRelationFixture"] = field(default_factory=list)  # req to create model
+    optional_relations: list["ModelRelationFixture"] = field(default_factory=list)  # not required
 
     @property
     def all_relations(self):


### PR DESCRIPTION
This PR replaces flake8 and isort with ruff. Ruff does everything these two linters do, but it is quite fast. See https://github.com/charliermarsh/ruff 