### PR TITLE
Pin FastAPI version to 0.86.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 # this is used by Heroku to install the environment
 # we should always be pinning specific versions for deployment
 aiohttp==3.8.1
-fastapi==0.71.0
+fastapi==0.86.0
 gidgethub==5.1.0
-sqlmodel==0.0.7  # https://github.com/tiangolo/sqlmodel/issues/315#issuecomment-1229239354
+sqlmodel>=0.0.8
 alembic==1.7.5
 PyYAML==6.0
 cffi

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,11 +27,11 @@ packages = find:
 include_package_data = True
 install_requires =
     aiohttp >= 3.8.1
-    fastapi >= 0.70.0
+    fastapi == 0.86.0
     gidgethub >= 5.1.0
-    sqlmodel >= 0.0.7  # https://github.com/tiangolo/sqlmodel/issues/315#issuecomment-1229239354
+    sqlmodel >= 0.0.8
     psycopg2-binary  # for postgres
-    pangeo-forge-runner == 0.6.1
+    pangeo-forge-runner == 0.7.0
 
 [options.extras_require]
 dev =


### PR DESCRIPTION
It appears the new FastAPI version (https://github.com/tiangolo/fastapi/releases/tag/0.87.0) introduced breaking changes to `TestClient` via `starlette`. 

This PR pins the version of `FastAPI` to 0.86.0 until 
- https://github.com/tiangolo/fastapi/issues/5644 is addressed
