### PR TITLE
Unpin FastAPI and fix tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # this is used by Heroku to install the environment
 # we should always be pinning specific versions for deployment
 aiohttp==3.8.1
-fastapi==0.86.0
+fastapi>=0.87.0
 gidgethub==5.1.0
 sqlmodel>=0.0.8
 alembic==1.7.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ packages = find:
 include_package_data = True
 install_requires =
     aiohttp >= 3.8.1
-    fastapi == 0.86.0
+    fastapi >= 0.87.0
     gidgethub >= 5.1.0
     sqlmodel >= 0.0.8
     psycopg2-binary  # for postgres
@@ -47,7 +47,7 @@ dev =
     types-requests
     uvicorn >= 0.15.0
     gunicorn
-    httpx
+    httpx >= 0.22
     asgi-lifespan  # https://github.com/tiangolo/fastapi/issues/2003#issuecomment-801140731
 
 [options.entry_points]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -27,7 +27,7 @@ create_params_incomplete = [
 def test_create_incomplete(path: str, create_opts: APIOpts, required_arg: str, client):
     create_kwargs = create_opts.copy()
     del create_kwargs[required_arg]
-    with pytest.raises(client.error_cls, match="422 Client Error: Unprocessable Entity"):
+    with pytest.raises(client.error_cls, match="Client error '422 Unprocessable Entity' for url"):
         with client.auth_required():
             _ = client.create(path, create_kwargs)
 
@@ -44,7 +44,7 @@ create_params_invalid = [
 def test_create_invalid(create_opts: APIOpts, invalid_arg, model_fixture, client):
     create_kwargs = create_opts.copy()
     create_kwargs.update(invalid_arg)
-    with pytest.raises(client.error_cls, match="422 Client Error: Unprocessable Entity"):
+    with pytest.raises(client.error_cls, match="Client error '422 Unprocessable Entity' for url"):
         with client.auth_required():
             _ = client.create(model_fixture.path, create_kwargs)
 


### PR DESCRIPTION
- #193 follow up 
- Thanks to @Kludex's [comment](https://github.com/tiangolo/fastapi/issues/5644#issuecomment-1314374964) i was able to fix the failing tests by setting the lower bound version for httpx to `v0.22`