### PR TITLE
Specify `apache-beam==2.43.0`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,9 +39,6 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.
     && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | tee /usr/share/keyrings/cloud.google.gpg \
     && apt-get update && apt-get -y install google-cloud-cli
 
-COPY requirements.txt ./
-RUN python3.9 -m pip install -r requirements.txt
-
 COPY . /opt/app
 WORKDIR /opt/app
 
@@ -55,6 +52,10 @@ RUN git clone -b main --single-branch https://github.com/pangeo-forge/dataflow-s
     && cd dataflow-status-monitoring \
     && git reset --hard c72a594b2aea5db45d6295fadd801673bee9746f \
     && cd -
+
+# pip installs after git install, in case we want to use upstream versions from github
+COPY requirements.txt ./
+RUN python3.9 -m pip install -r requirements.txt
 
 # the only deploy-time process which needs pangeo_forge_orchestrator installed is the review app's
 # `postdeploy/seed_review_app_data.py`, but this shouldn't interfere with anything else.

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,21 +15,18 @@ psycopg2-binary==2.9.3
 
 # these will eventually move out of the app container, and instead be
 # installed within the docker sibling container used for recipe handling
-pangeo-forge-runner==0.7.0
+
+# todo: pin to a release of pangeo-forge-runner, if we get one before
+# all of these deps move out of this container, which will happen after
+# https://github.com/pangeo-forge/pangeo-forge-orchestrator/pull/204 goes in
+git+https://github.com/pangeo-forge/pangeo-forge-runner.git@recipes-0.9.4
+
 gcsfs==2022.8.2
 s3fs==2022.8.2
 google-auth-oauthlib==0.5.3 # remove this once https://github.com/fsspec/gcsfs/issues/505 has been addressed
-# override/upgrade recipes version brought in by pangeo-forge-runner
-# NOTE: once https://github.com/pangeo-forge/pangeo-forge-orchestrator/pull/204 goes in,
-# this install will be dropped from here, so not worrying about patching this in for now,
-# as it's a short-term fix to get newly released features into the GitHub integration.
-pangeo-forge-recipes==0.9.4
 # required for netcdf3 recipes, again this will move out of the app container once recipe
 # parsing no longer runs in the same container as the FastAPI application. patching for now.
 kerchunk[netcdf3]==0.0.7
-# the latest `pangeo/forge:8904ade` uses this, so we need it in the parsing environment
-# separating parsing out from this app will resolve all this version patching
-apache-beam==2.43.0
 
 # these will eventually be brought into the recipe parsing container dynamically
 # from requirements.txt, environment.yml, etc. For now, we are hardcoding so that

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,9 @@ pangeo-forge-recipes==0.9.4
 # required for netcdf3 recipes, again this will move out of the app container once recipe
 # parsing no longer runs in the same container as the FastAPI application. patching for now.
 kerchunk[netcdf3]==0.0.7
+# the latest `pangeo/forge:8904ade` uses this, so we need it in the parsing environment
+# separating parsing out from this app will resolve all this version patching
+apache-beam==2.43.0
 
 # these will eventually be brought into the recipe parsing container dynamically
 # from requirements.txt, environment.yml, etc. For now, we are hardcoding so that


### PR DESCRIPTION
This is yet another version patch which further underscores the importance of moving recipe parsing out of the FastAPI container, which will be accomplished with #204.

I believe this reported failure https://github.com/pangeo-forge/C-iTRACE-feedstock/pull/5#issuecomment-1374381446 was caused by the `apache-beam` version mismatch (between parsing and worker containers) resolved by this PR.

The "better" solution is probably to fix this [in pangeo-forge-runner](https://github.com/pangeo-forge/pangeo-forge-runner/blob/43690d5a16d43da85995651b55f7f4635a66a1bd/setup.py#L23) but ideally this will be the last such patch that needs to go in before merging #204, at which point the need for this type of fix should basically disappear, so don't want to spend too much effort on what should be a very temporary bandaid solution.