### PR TITLE
Upgrade to python 3.10

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.10]
+        python-version: ['3.10']
         database: ['sqlite', 'postgres']
 
     steps:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9]
+        python-version: [3.10]
         database: ['sqlite', 'postgres']
 
     steps:

--- a/.github/workflows/test-docker.yaml
+++ b/.github/workflows/test-docker.yaml
@@ -32,7 +32,7 @@ jobs:
           docker-compose run
           -v ${PWD}/tests:/opt/app/tests
           --entrypoint="/bin/sh -c 'sleep 1
-          && python3.9 -m alembic upgrade head
+          && python3.10 -m alembic upgrade head
           && apt-get install -y git
           && pip install \".[dev]\"
           && pytest tests -vx'"

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,16 +10,15 @@ RUN make install
 
 FROM ubuntu:22.04
 COPY --from=0 /go/bin/sops /usr/local/bin/sops
-# we need python3.9 because apache beam is not supported on 3.10
-# is the best way to get 3.9 on ubuntu? https://askubuntu.com/a/682875
+# is the best way to get 3.10 on ubuntu? https://askubuntu.com/a/682875
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get -y install tzdata software-properties-common \
     && add-apt-repository ppa:deadsnakes/ppa \
-    && apt-get update && apt-get -y install python3.9-dev python3.9-distutils
+    && apt-get update && apt-get -y install python3.10-dev python3.10-distutils
 RUN apt-get update && apt-get -y install curl wget unzip apt-transport-https ca-certificates
 # is this the best way to get pip for python 3.10? https://stackoverflow.com/a/65644846
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
-    && python3.10 get-pip.py
+    && python3 get-pip.py
 
 # Install terraform, which we need for release (could be a separate build stage in the future)\
 ENV TF_VERSION 1.1.4
@@ -55,7 +54,7 @@ RUN git clone -b main --single-branch https://github.com/pangeo-forge/dataflow-s
 
 # pip installs after git install, in case we want to use upstream versions from github
 COPY requirements.txt ./
-RUN python3.9 -m pip install -r requirements.txt
+RUN python3.10 -m pip install -r requirements.txt
 
 # the only deploy-time process which needs pangeo_forge_orchestrator installed is the review app's
 # `postdeploy/seed_review_app_data.py`, but this shouldn't interfere with anything else.

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,9 @@ RUN apt-get update \
     && add-apt-repository ppa:deadsnakes/ppa \
     && apt-get update && apt-get -y install python3.9-dev python3.9-distutils
 RUN apt-get update && apt-get -y install curl wget unzip apt-transport-https ca-certificates
-# is this the best way to get pip for python 3.9? https://stackoverflow.com/a/65644846
+# is this the best way to get pip for python 3.10? https://stackoverflow.com/a/65644846
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
-    && python3.9 get-pip.py
+    && python3.10 get-pip.py
 
 # Install terraform, which we need for release (could be a separate build stage in the future)\
 ENV TF_VERSION 1.1.4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,14 +33,14 @@ services:
     #     - We bind to 0.0.0.0 (as opposed to default 127.0.0.1) to make port binding to host work
     entrypoint: >
       /bin/sh -c 'sleep 1
-      && python3.9 -m alembic upgrade head
+      && python3.10 -m alembic upgrade head
       && aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
       && aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
       && sops -d -i ./secrets/bakery-args.pangeo-ldeo-nsf-earthcube.yaml
       && sops -d -i ./secrets/config.$${PANGEO_FORGE_DEPLOYMENT}.yaml
       && sops -d -i $${DATAFLOW_CREDS}
       && gcloud auth activate-service-account --key-file=$${DATAFLOW_CREDS}
-      && cat $${DATAFLOW_CREDS} | python3.9 -c "$$GET_PROJECT_ID" | xargs -I{} gcloud config set project {}
+      && cat $${DATAFLOW_CREDS} | python3.10 -c "$$GET_PROJECT_ID" | xargs -I{} gcloud config set project {}
       && export GOOGLE_APPLICATION_CREDENTIALS=$${DATAFLOW_CREDS}
       && gunicorn -w 1 -t 300 -k uvicorn.workers.UvicornWorker pangeo_forge_orchestrator.api:app -b 0.0.0.0:8000'
   db:

--- a/heroku.yml
+++ b/heroku.yml
@@ -23,7 +23,7 @@ run:
     && sops -d -i ${DATAFLOW_CREDS}
     && gcloud auth activate-service-account --key-file=${DATAFLOW_CREDS}
     && cat ${DATAFLOW_CREDS}
-    | python3.9 -c "import sys, json; print(json.load(sys.stdin)['project_id'].strip())"
+    | python3.10 -c "import sys, json; print(json.load(sys.stdin)['project_id'].strip())"
     | xargs -I{} gcloud config set project {}
     && export GOOGLE_APPLICATION_CREDENTIALS=${DATAFLOW_CREDS}
     && export BAKERY_SECRETS='./secrets/bakery-args.pangeo-ldeo-nsf-earthcube.yaml'

--- a/scripts.deploy/release.sh
+++ b/scripts.deploy/release.sh
@@ -7,7 +7,7 @@ export GOOGLE_APPLICATION_CREDENTIALS="`pwd`/${TF_CREDS}"
 export GET_GCP_PROJECT="import sys, json; print(json.load(sys.stdin)['project_id'].strip())"
 
 echo "running database migration..."
-python3.9 -m alembic upgrade head
+python3.10 -m alembic upgrade head
 
 if [[ -z "${PANGEO_FORGE_DEPLOYMENT}" ]]; then
   echo "PANGEO_FORGE_DEPLOYMENT undefined, so this must be a review app..."
@@ -39,7 +39,7 @@ if deployment not in ('pangeo-forge', 'pangeo-forge-staging'):
 else:
     print(deployment)
 "
-export TF_ENV=$(python3.9 -c "${SET_TF_ENV}")
+export TF_ENV=$(python3.10 -c "${SET_TF_ENV}")
 echo "terraform env set to '${TF_ENV}'"
 
 echo "setting aws config for kms access..."
@@ -64,7 +64,7 @@ print(apps)
 "
 # set this as an env var (rather than assigning it directly to `app_array`),
 # because it is also used in the `GET_APPS_WITH_SECRETS` python command below.
-export APP_NAMES=$(python3.9 -c "${PARSE_APP_NAMES}")
+export APP_NAMES=$(python3.10 -c "${PARSE_APP_NAMES}")
 
 app_array=$APP_NAMES
 for app in ${app_array[@]}; do
@@ -82,11 +82,11 @@ for a in os.environ['APP_NAMES'].split():
         apps_with_secrets.update({a: secret})
 print(json.dumps(apps_with_secrets))
 "
-export APPS_WITH_SECRETS=$(python3.9 -c "${GET_APPS_WITH_SECRETS}")
+export APPS_WITH_SECRETS=$(python3.10 -c "${GET_APPS_WITH_SECRETS}")
 
 echo "dynamically setting gcp project from service account keyfile..."
 sops -d -i "./${TF_CREDS}"
-export GCP_PROJECT=$(cat ./${TF_CREDS} | python3.9 -c "${GET_GCP_PROJECT}")
+export GCP_PROJECT=$(cat ./${TF_CREDS} | python3.10 -c "${GET_GCP_PROJECT}")
 
 echo "running terraform for env '${TF_ENV}'..."
 terraform -chdir='./terraform/'${TF_ENV} init


### PR DESCRIPTION
Dataflow workers are still not starting, and I think this is why (the latest worker container we're using is python 3.10!).

I've written this same comment on a number of recent PRs, but all of this version wrangling _really_ confirms to me the value of moving recipe parsing out of the FastAPI container, which #204 will achieve.

