### PR TITLE
Upgrade uvicorn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ cffi
 
 # for deployment
 gunicorn==20.1.0
-uvicorn==0.17.0
+uvicorn==0.20.0
 psycopg2-binary==2.9.3
 
 # these will eventually move out of the app container, and instead be


### PR DESCRIPTION
I trying to figure out the cause of #220 and the hanging CI task observed in https://github.com/pangeo-forge/staged-recipes/pull/247#issuecomment-1397460538, the common denominator (based on review of our Papertrail logs) appear to be worker timeouts.

The specific cause of these timeouts remains unclear to me, but I did realize that the version of Uvicorn we're using in production has since been yanked. So I'm upgrading to the latest Uvicorn in this PR, in hopes that may help.