### PR TITLE
Dataflow integration test inside app container

### DIFF
--- a/.github/workflows/test-dataflow-integration.yaml
+++ b/.github/workflows/test-dataflow-integration.yaml
@@ -24,7 +24,6 @@ on:
 
 jobs:
   build:
-    name: ${{ matrix.python-version }}
     # run on:
     #  - all pushes to main & prod
     #  - schedule defined above
@@ -45,7 +44,7 @@ jobs:
           ref: main
       - name: Cache test file from runner to local disk
         run: |
-          cp ./test/integration/dataflow_integration_test.py ~/
+          cp ./tests/integration/dataflow_integration_test.py ~/
       - name: Checkout -ochestrator repo
         uses: actions/checkout@v3
       - name: Print test file for reference

--- a/.github/workflows/test-dataflow-integration.yaml
+++ b/.github/workflows/test-dataflow-integration.yaml
@@ -1,0 +1,57 @@
+# This test mirrors the one added to pangeo-forge-runner in
+# https://github.com/pangeo-forge/pangeo-forge-runner/pull/52,
+# with the only difference being that it's deployed from inside our production
+# container. Experience has shown that testing this does matter, given that
+# differences between the client (i.e. deploying/submitting) environment and the
+# Dataflow worker environment can result in serialization issues on Dataflow.
+
+# FIXME: Once https://github.com/pangeo-forge/pangeo-forge-orchestrator/pull/204
+# goes in, we'll need to change this test so that it is run from within the Cloud
+# Run container which will be used for recipe parsing in production. Perhaps this
+# means we'll want to just move this test to the repo which defines the Cloud Run
+# service. TBD.
+
+name: Dataflow Integration Test
+
+on:
+  push:
+    branches: ['main', 'prod']
+  pull_request:
+    branches: ['main']
+    types: [opened, reopened, synchronize, labeled]
+  schedule:
+    - cron: '0 4 * * *' # run once a day at 4 AM
+
+jobs:
+  build:
+    name: ${{ matrix.python-version }}
+    # run on:
+    #  - all pushes to main & prod
+    #  - schedule defined above
+    #  - a PR was just labeled 'test-dataflow'
+    #  - a PR with 'test-dataflow' label was opened, reopened, or synchronized
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'schedule' ||
+      github.event.label.name == 'test-dataflow' ||
+      contains( github.event.pull_request.labels.*.name, 'test-dataflow')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout -runner repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          repo: pangeo-forge/pangeo-forge-runner
+          ref: main
+      - name: Cache test file from runner to local disk
+        run: |
+          cp ./test/integration/dataflow_integration_test.py ~/
+      - name: Checkout -ochestrator repo
+        uses: actions/checkout@v3
+      - name: Print test file for reference
+        run: |
+          cat ~/dataflow_integration_test.py
+      - name: Build app container
+        run: |
+          docker build -t dataflow-integration . --platform=linux/amd64
+    # - name: Run test in app container

--- a/.github/workflows/test-dataflow-integration.yaml
+++ b/.github/workflows/test-dataflow-integration.yaml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          repo: pangeo-forge/pangeo-forge-runner
+          repository: pangeo-forge/pangeo-forge-runner
           ref: main
       - name: Cache test file from runner to local disk
         run: |

--- a/.github/workflows/test-dataflow-integration.yaml
+++ b/.github/workflows/test-dataflow-integration.yaml
@@ -42,11 +42,9 @@ jobs:
         with:
           repository: pangeo-forge/pangeo-forge-runner
           path: './pangeo-forge-runner'
-      - name: list
-        run: ls -la ./pangeo-forge-runner
       - name: Print test file for reference
         run: |
-          cat ./pangeo-forge-runner/tests/integration/dataflow_integration_test.py
+          cat ./pangeo-forge-runner/tests/integration/test_dataflow_integration.py
       - name: Build app container
         run: |
           docker build -t dataflow-integration . --platform=linux/amd64

--- a/.github/workflows/test-dataflow-integration.yaml
+++ b/.github/workflows/test-dataflow-integration.yaml
@@ -36,20 +36,15 @@ jobs:
       contains( github.event.pull_request.labels.*.name, 'test-dataflow')
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - name: Checkout -runner repo
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0
           repository: pangeo-forge/pangeo-forge-runner
-          ref: main
-      - name: Cache test file from runner to local disk
-        run: |
-          cp ${{ github.workspace }}/tests/integration/dataflow_integration_test.py ~/
-      - name: Checkout -ochestrator repo
-        uses: actions/checkout@v3
+          path: './pangeo-forge-runner'
       - name: Print test file for reference
         run: |
-          cat ~/dataflow_integration_test.py
+          cat ./pangeo-forge-runner/tests/integration/dataflow_integration_test.py
       - name: Build app container
         run: |
           docker build -t dataflow-integration . --platform=linux/amd64

--- a/.github/workflows/test-dataflow-integration.yaml
+++ b/.github/workflows/test-dataflow-integration.yaml
@@ -44,7 +44,7 @@ jobs:
           ref: main
       - name: Cache test file from runner to local disk
         run: |
-          cp ./tests/integration/dataflow_integration_test.py ~/
+          cp /tests/integration/dataflow_integration_test.py ~/
       - name: Checkout -ochestrator repo
         uses: actions/checkout@v3
       - name: Print test file for reference

--- a/.github/workflows/test-dataflow-integration.yaml
+++ b/.github/workflows/test-dataflow-integration.yaml
@@ -44,7 +44,7 @@ jobs:
           ref: main
       - name: Cache test file from runner to local disk
         run: |
-          cp ${{ env.GITHUB_WORKSPACE }}/tests/integration/dataflow_integration_test.py ~/
+          cp ${{ github.workspace }}/tests/integration/dataflow_integration_test.py ~/
       - name: Checkout -ochestrator repo
         uses: actions/checkout@v3
       - name: Print test file for reference

--- a/.github/workflows/test-dataflow-integration.yaml
+++ b/.github/workflows/test-dataflow-integration.yaml
@@ -42,6 +42,8 @@ jobs:
         with:
           repository: pangeo-forge/pangeo-forge-runner
           path: './pangeo-forge-runner'
+      - name: list
+        run: ls -la
       - name: Print test file for reference
         run: |
           cat ./pangeo-forge-runner/tests/integration/dataflow_integration_test.py

--- a/.github/workflows/test-dataflow-integration.yaml
+++ b/.github/workflows/test-dataflow-integration.yaml
@@ -43,7 +43,7 @@ jobs:
           repository: pangeo-forge/pangeo-forge-runner
           path: './pangeo-forge-runner'
       - name: list
-        run: ls -la
+        run: ls -la ./pangeo-forge-runner
       - name: Print test file for reference
         run: |
           cat ./pangeo-forge-runner/tests/integration/dataflow_integration_test.py

--- a/.github/workflows/test-dataflow-integration.yaml
+++ b/.github/workflows/test-dataflow-integration.yaml
@@ -44,7 +44,7 @@ jobs:
           ref: main
       - name: Cache test file from runner to local disk
         run: |
-          cp /tests/integration/dataflow_integration_test.py ~/
+          cp ${{ env.GITHUB_WORKSPACE }}/tests/integration/dataflow_integration_test.py ~/
       - name: Checkout -ochestrator repo
         uses: actions/checkout@v3
       - name: Print test file for reference


### PR DESCRIPTION
The workflow added here runs the exact test added to runner in https://github.com/pangeo-forge/pangeo-forge-runner/pull/52 _**inside the orchestrator app container**_. This should give us additional confidence that there is nothing specific about our client (i.e. app container) environment causing Dataflow submission issues. In the case where this test is passing in pangeo-forge-runner, but failing here, we will know the issue has to do with our app container environment.